### PR TITLE
Persistent storage implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Wushu Nantes-Cholet-Angers - Backend & Services project
 This project aims at providing the backend services to be used to support a sports club practicing Wushu
+
+## Default testing data
+Testing data is declared in `import.sql`.
+
+To load data on first start or to reset data with defaults, change `spring.jpa.hibernate.ddl-auto` property value (in `application.properties`) with either `create` or `create-drop`.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.datasource.url=jdbc:h2:file:~/kungfuclub-db
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,0 +1,1 @@
+INSERT INTO profile (id, firstname, lastname) VALUES (1, 'Prenom', 'Nom');


### PR DESCRIPTION
#3 

Configuration of the persistent storage : 
- h2 database now persistent after full restart of the server/computer
- `import.sql` contains testing data. To load data on first start or to reset data with defaults, change `spring.jpa.hibernate.ddl-auto` property value (in `application.properties`) with either `create-drop` or `create`.